### PR TITLE
Change status page source to GitHub Pages to avoid cache delay

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -263,7 +263,7 @@
 
 [statusData]
     # URL for publicly-shared CSV view of Google Sheet with CEDA status updates
-    "sourceURL" = "https://raw.githubusercontent.com/cedadev/ceda-status/main/status.json"
+    "sourceURL" = "https://cedadev.github.io/ceda-status/status.json"
     "viewURL" = "https://github.com/cedadev/ceda-status/blob/main/status.json"
 
 #[modules.cookieyes]


### PR DESCRIPTION
Change path to a new source for status.json. This removes the ~5 minute cache delay from githubusercontent AND ensures that the validation passes before publication

See https://github.com/cedadev/ceda-status/blob/main/.github/workflows/static.yml for details of the new workflow